### PR TITLE
Use constructor instead of block for dry configurable

### DIFF
--- a/lib/jay_doubleu_tee.rb
+++ b/lib/jay_doubleu_tee.rb
@@ -14,11 +14,11 @@ module JayDoubleuTee
 
   extend Dry::Configurable
 
-  setting :algorithm, default: 'RS256' do |value|
+  setting :algorithm, default: 'RS256', constructor: ->(value) do
     raise ConfigurationError, "Unsupported algorithm." unless ALGORITHMS.include?(value)
     value
   end
-
+  
   setting :secret, default: ENV['JAY_DOUBLEU_TEE_PUBLIC_KEY']
 
   setting :authorize_by_default, default: true

--- a/lib/jay_doubleu_tee.rb
+++ b/lib/jay_doubleu_tee.rb
@@ -18,7 +18,7 @@ module JayDoubleuTee
     raise ConfigurationError, "Unsupported algorithm." unless ALGORITHMS.include?(value)
     value
   end
-  
+
   setting :secret, default: ENV['JAY_DOUBLEU_TEE_PUBLIC_KEY']
 
   setting :authorize_by_default, default: true


### PR DESCRIPTION
Providing a block while passing settings to Dry::Configurable is deprecated. see: https://github.com/dry-rb/dry-configurable/commit/b118da004fa65772f25518046e4e77eaafc3b9fe